### PR TITLE
Restore groupId to sc.fiji

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 		<relativePath />
 	</parent>
 
+	<groupId>sc.fiji</groupId>
 	<artifactId>TrackMate_trackanalysis</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 


### PR DESCRIPTION
The groupId was accidentally changed in commit 9cddbea when switching to pom-scijava as parent POM.

@tinevez how about cutting a release now after merging this, using [`release-version.sh`](https://github.com/scijava/scijava-scripts/blob/cd736c70c08278b426bde01b6ac7e2ab63bbbdc7/release-version.sh)?