### PR TITLE
Bump parent to pom-scijava 29.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>28.0.0</version>
+		<version>29.2.1</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/fiji/plugin/trackmate/features/track/LinearTrackDescriptor.java
+++ b/src/main/java/fiji/plugin/trackmate/features/track/LinearTrackDescriptor.java
@@ -14,6 +14,7 @@ import javax.swing.ImageIcon;
 import net.imglib2.multithreading.SimpleMultiThreading;
 
 import org.jgrapht.graph.DefaultWeightedEdge;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 import fiji.plugin.trackmate.Dimension;
@@ -23,7 +24,7 @@ import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.features.edge.LinearTrackEdgeStatistics;
 
 @SuppressWarnings( "deprecation" )
-@Plugin( type = TrackAnalyzer.class, priority = 1d )
+@Plugin( type = TrackAnalyzer.class, priority = Priority.LOW )
 public class LinearTrackDescriptor implements TrackAnalyzer
 {
 

--- a/src/test/java/fiji/plugin/trackmate/features/track/LinearTrackDescriptorTest.java
+++ b/src/test/java/fiji/plugin/trackmate/features/track/LinearTrackDescriptorTest.java
@@ -10,6 +10,7 @@ import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.features.ModelFeatureUpdater;
+import fiji.plugin.trackmate.providers.TrackAnalyzerProvider;
 
 public class LinearTrackDescriptorTest
 {
@@ -21,11 +22,8 @@ public class LinearTrackDescriptorTest
 	{
 		model = new Model();
 		Settings settings = new Settings();
-		settings.addTrackAnalyzer( new TrackIndexAnalyzer() );
-		settings.addTrackAnalyzer( new TrackDurationAnalyzer() );
-		settings.addTrackAnalyzer( new TrackSpeedStatisticsAnalyzer() );
-		settings.addTrackAnalyzer( new LinearTrackDescriptor() );
-		// settings.addEdgeAnalyzer( new LinearTrackEdgeStatistics() );
+		// NB: populate TrackAnalyzers in the order of SciJava priority
+		populateTrackAnalyzers(settings);
 		new ModelFeatureUpdater( model, settings );
 
 		model.beginUpdate();
@@ -34,6 +32,15 @@ public class LinearTrackDescriptorTest
 		double[][] track2points = new double[][] { { 4, 2, 0 }, { 6, 2, 0 }, { 8, 2, 0 }, { 9, 2, 0 }, { 10, 8, 0 } };
 		createTrack( track2points );
 		model.endUpdate();
+	}
+
+	private void populateTrackAnalyzers( Settings s )
+	{
+		TrackAnalyzerProvider trackAnalyzerProvider = new TrackAnalyzerProvider();
+		for ( String key : trackAnalyzerProvider.getKeys() )
+		{
+			s.addTrackAnalyzer( trackAnalyzerProvider.getFactory( key ) );
+		}
 	}
 
 	private void createTrack( double[][] points )


### PR DESCRIPTION
This increases the TrackMate version to `6.0.0`, which changes the handling of priorities to follow standard SciJava priorities.

Therefore, we need to update the priority of `LinearTrackDescriptor` to `Priority.LOW`.

While at it, let's change the test to use the actual runtime priorities. The adapted test fails with the previous `priority=1d`, but passes with `priority=Priority.LOW`.